### PR TITLE
Improve Local Setup Robustness with Heartbeat Health Check

### DIFF
--- a/scripts/openclaw-local/README.md
+++ b/scripts/openclaw-local/README.md
@@ -137,6 +137,7 @@ All variables have sensible defaults. Edit `.env.openclaw-local` to override.
 | `VLLM_HEALTH_URL` | `http://127.0.0.1:8000/health` | vLLM health endpoint monitored by supervisor |
 | `VLLM_MODELS_URL` | `http://127.0.0.1:8000/v1/models` | vLLM models endpoint used for readiness checks |
 | `CLAAS_API_HEALTH_URL` | `http://127.0.0.1:8080/v1/health` | CLaaS API health endpoint monitored by supervisor |
+| `CLAAS_API_WAIT_SECONDS` | `60` | Startup grace window for CLaaS API before monitor checks begin |
 
 ## LoRA Adapters
 

--- a/scripts/openclaw-local/openclaw-local.env.example
+++ b/scripts/openclaw-local/openclaw-local.env.example
@@ -32,6 +32,7 @@ RESTART_BACKOFF_SECONDS=3
 VLLM_HEALTH_URL=http://127.0.0.1:8000/health
 VLLM_MODELS_URL=http://127.0.0.1:8000/v1/models
 CLAAS_API_HEALTH_URL=http://127.0.0.1:8080/v1/health
+CLAAS_API_WAIT_SECONDS=60
 
 # OpenClaw model mapping
 MODEL_IDS=qwen3-8b,openclaw-assistant-latest


### PR DESCRIPTION
Codex generated this pull request, but encountered an unexpected error after generation. This is a placeholder PR message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fb6dbfe94832e8b637dbe7d9899e3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Supervisor continuously monitors service health endpoints and model readiness, scans logs for OOM/crash signatures, persists OOM state across restarts, and automatically restarts the local stack when issues are detected.
  * Added configurable env vars for monitoring and restart behavior (monitor interval, restart backoff, vLLM/CLaaS health and models endpoints, CLaaS wait time, and OOM state file locations).

* **Documentation**
  * Updated Quick Start and local setup guidance to describe automatic monitoring, restart behavior, and adjusted OOM guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->