### PR TITLE
Refactor recent feedback page to template-driven expandable table

### DIFF
--- a/claas/api.py
+++ b/claas/api.py
@@ -27,6 +27,7 @@ Example usage (feedback)::
 from __future__ import annotations
 
 import asyncio
+import html
 import json
 import logging
 import os
@@ -38,8 +39,8 @@ from typing import Any
 
 import httpx
 import modal
-from fastapi import FastAPI, HTTPException
-from fastapi.responses import Response
+from fastapi import FastAPI, HTTPException, Query
+from fastapi.responses import HTMLResponse, Response
 
 from .storage import LORA_MOUNT_PATH, lora_volume
 from .teacher import format_teacher_prompt
@@ -76,6 +77,9 @@ web_app = FastAPI(
 VLLM_BASE_URL = os.environ.get("VLLM_BASE_URL", "http://127.0.0.1:8000")
 VLLM_API_KEY = os.environ.get("VLLM_API_KEY", "sk-local")
 FEEDBACK_LOG_DIR = os.environ.get("FEEDBACK_LOG_DIR", "./feedback_logs")
+FEEDBACK_DASHBOARD_TEMPLATE = (
+    Path(__file__).resolve().parent / "templates" / "feedback_recent" / "index.html"
+)
 FEEDBACK_LOCK_TIMEOUT_S = float(os.environ.get("FEEDBACK_LOCK_TIMEOUT_S", "120"))
 # Default "local" assumes GPU deps (torch, etc.) are available on this machine.
 # Set to "modal" for Modal deployments where the API image is CPU-only.
@@ -359,6 +363,129 @@ def _write_feedback_log(record: dict[str, Any] | FeedbackLogRecord) -> str:
     with path.open("w", encoding="utf-8") as f:
         json.dump(payload, f, indent=2, sort_keys=True)
     return str(path)
+
+
+def _read_recent_feedback_logs(limit: int = 20) -> list[FeedbackLogRecord]:
+    """Load recent feedback records from disk.
+
+    Args:
+        limit: Maximum number of records to load.
+
+    Returns:
+        A list of feedback records ordered from newest to oldest.
+    """
+    log_root = Path(FEEDBACK_LOG_DIR)
+    if not log_root.exists():
+        return []
+
+    log_paths = sorted(log_root.glob("*.json"), reverse=True)
+    selected_paths = log_paths[:limit]
+    records: list[FeedbackLogRecord] = []
+    for path in selected_paths:
+        with path.open("r", encoding="utf-8") as file_obj:
+            payload = json.load(file_obj)
+        records.append(FeedbackLogRecord.model_validate(payload))
+    return records
+
+
+def _feedback_prompt_preview(prompt: str, limit: int = 140) -> str:
+    """Build a single-line prompt preview for table display.
+
+    Args:
+        prompt: Full prompt text.
+        limit: Maximum preview length.
+
+    Returns:
+        Prompt preview trimmed to the requested length.
+    """
+    normalized = " ".join(prompt.splitlines())
+    if len(normalized) <= limit:
+        return normalized
+    return f"{normalized[:limit]}…"
+
+
+def _feedback_dashboard_rows(records: list[FeedbackLogRecord]) -> str:
+    """Render dashboard table rows for feedback records.
+
+    Args:
+        records: Feedback records to render.
+
+    Returns:
+        HTML table rows with expandable detail sections.
+    """
+    rows: list[str] = []
+    for index, record in enumerate(records):
+        detail_row_id = f"feedback-detail-{index}"
+        metrics_payload = {}
+        if record.distill_result is not None:
+            metrics_payload = record.distill_result.metadata
+        timing_json = json.dumps(record.timing_ms.model_dump(mode="json"), indent=2, sort_keys=True)
+        metrics_json = json.dumps(metrics_payload, indent=2, sort_keys=True)
+        vllm_json = json.dumps(record.vllm.model_dump(mode="json"), indent=2, sort_keys=True)
+        error_value = record.error or ""
+        prompt_preview = _feedback_prompt_preview(record.request.prompt)
+
+        rows.append(
+            """
+            <tr>
+              <td>{request_id}<br><small>{timestamp}</small></td>
+              <td>{status} ({phase})</td>
+              <td>{lora_id}</td>
+              <td><div class="prompt-preview">{prompt_preview}</div></td>
+              <td>{distill_ms}</td>
+              <td>{total_ms}</td>
+              <td><button type="button" onclick="toggleDetails('{detail_row_id}', this)">Expand</button></td>
+            </tr>
+            <tr id="{detail_row_id}" class="detail-row">
+              <td colspan="7">
+                <div class="detail-panel">
+                  <section><h3>Prompt</h3><pre>{prompt}</pre></section>
+                  <section><h3>Response</h3><pre>{response}</pre></section>
+                  <section><h3>Feedback</h3><pre>{feedback}</pre></section>
+                  <section><h3>Timing (ms)</h3><pre>{timing_json}</pre></section>
+                  <section><h3>Training metrics</h3><pre>{metrics_json}</pre></section>
+                  <section><h3>vLLM orchestration</h3><pre>{vllm_json}</pre></section>
+                  <section><h3>Error</h3><pre>{error_value}</pre></section>
+                </div>
+              </td>
+            </tr>
+            """.format(
+                request_id=html.escape(record.request_id),
+                timestamp=html.escape(record.timestamp_utc),
+                status=html.escape(record.status),
+                phase=html.escape(record.phase),
+                lora_id=html.escape(record.lora_id),
+                prompt_preview=html.escape(prompt_preview),
+                distill_ms=record.timing_ms.distill,
+                total_ms=record.timing_ms.total,
+                detail_row_id=detail_row_id,
+                prompt=html.escape(record.request.prompt),
+                response=html.escape(record.request.response),
+                feedback=html.escape(record.request.feedback),
+                timing_json=html.escape(timing_json),
+                metrics_json=html.escape(metrics_json),
+                vllm_json=html.escape(vllm_json),
+                error_value=html.escape(error_value),
+            )
+        )
+
+    if not rows:
+        return '<tr><td colspan="7">No feedback records found.</td></tr>'
+    return "\n".join(rows)
+
+
+def _feedback_dashboard_html(records: list[FeedbackLogRecord]) -> str:
+    """Render feedback records into the dashboard HTML template.
+
+    Args:
+        records: Feedback records to display.
+
+    Returns:
+        Rendered HTML content.
+    """
+    template = FEEDBACK_DASHBOARD_TEMPLATE.read_text(encoding="utf-8")
+    table_rows = _feedback_dashboard_rows(records)
+    return template.replace("{{TABLE_ROWS}}", table_rows)
 
 
 
@@ -669,6 +796,21 @@ async def health_check() -> HealthResponse:
         teacher = ServiceHealth(status="healthy", error=None)
 
     return HealthResponse(status=status, worker=worker, teacher=teacher)
+
+
+@web_app.get("/v1/feedback/recent", response_class=HTMLResponse)
+async def recent_feedback_dashboard(limit: int = Query(default=20, ge=1, le=200)) -> HTMLResponse:
+    """Serve a minimal dashboard of recent feedback records.
+
+    Args:
+        limit: Maximum number of feedback records to render.
+
+    Returns:
+        HTML dashboard containing recent feedback details and metrics.
+    """
+    records = await asyncio.to_thread(_read_recent_feedback_logs, limit)
+    html_content = _feedback_dashboard_html(records)
+    return HTMLResponse(content=html_content)
 
 
 @web_app.get("/")

--- a/claas/templates/feedback_recent/index.html
+++ b/claas/templates/feedback_recent/index.html
@@ -1,0 +1,99 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>CLaaS Recent Feedback</title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: Inter, Arial, sans-serif;
+      }
+      body {
+        margin: 0;
+        padding: 1.5rem;
+        background: #f8fafc;
+        color: #0f172a;
+      }
+      h1 {
+        margin-top: 0;
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        background: #ffffff;
+        border: 1px solid #cbd5e1;
+      }
+      th,
+      td {
+        padding: 0.6rem;
+        border-bottom: 1px solid #e2e8f0;
+        text-align: left;
+        vertical-align: top;
+      }
+      th {
+        background: #e2e8f0;
+      }
+      .prompt-preview {
+        max-width: 40rem;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .detail-row {
+        display: none;
+        background: #f8fafc;
+      }
+      .detail-panel {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
+        gap: 0.75rem;
+      }
+      pre {
+        margin: 0;
+        white-space: pre-wrap;
+        word-break: break-word;
+        background: #f1f5f9;
+        border: 1px solid #cbd5e1;
+        border-radius: 6px;
+        padding: 0.6rem;
+        max-height: 20rem;
+        overflow: auto;
+      }
+      button {
+        cursor: pointer;
+      }
+    </style>
+    <script>
+      function toggleDetails(rowId, button) {
+        const detailRow = document.getElementById(rowId);
+        if (detailRow.style.display === 'table-row') {
+          detailRow.style.display = 'none';
+          button.textContent = 'Expand';
+          return;
+        }
+        detailRow.style.display = 'table-row';
+        button.textContent = 'Collapse';
+      }
+    </script>
+  </head>
+  <body>
+    <h1>CLaaS Recent Feedback</h1>
+    <table>
+      <thead>
+        <tr>
+          <th>Request</th>
+          <th>Status</th>
+          <th>LoRA</th>
+          <th>Prompt Preview</th>
+          <th>Distill (ms)</th>
+          <th>Total (ms)</th>
+          <th>Details</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{TABLE_ROWS}}
+      </tbody>
+    </table>
+  </body>
+</html>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -547,3 +547,159 @@ def test_feedback_tinker_accepts_default_orchestration(monkeypatch, tmp_path):
     )
 
     assert response.status_code == 200
+
+
+def test_recent_feedback_dashboard_renders_latest_records(monkeypatch, tmp_path):
+    from claas import api
+
+    monkeypatch.setattr(api, "FEEDBACK_LOG_DIR", str(tmp_path))
+
+    (tmp_path / "20240101T000001-a.json").write_text(
+        """
+{
+  "request_id": "a",
+  "timestamp_utc": "2024-01-01T00:00:01Z",
+  "status": "ok",
+  "phase": "done",
+  "lora_id": "user/model",
+  "teacher_mode": "self",
+  "request": {
+    "lora_id": "user/model",
+    "prompt": "prompt-a",
+    "response": "response-a",
+    "feedback": "feedback-a",
+    "rollout_logprobs": null,
+    "training": {
+      "learning_rate": 0.0001,
+      "alpha": 0.5,
+      "is_clip": 5.0,
+      "max_grad_norm": 1.0,
+      "kl_reg_weight": 0.001,
+      "teacher_top_k": 100,
+      "teacher_mode": "self"
+    },
+    "orchestration": {
+      "sleep_before": true,
+      "wake_after": true,
+      "wake_on_failure": true,
+      "sleep_level": 1
+    }
+  },
+  "vllm": {
+    "slept": true,
+    "woke": true
+  },
+  "timing_ms": {
+    "sleep": 1,
+    "distill": 2,
+    "save": 0,
+    "wake": 1,
+    "logprobs": 0,
+    "total": 4
+  },
+  "distill_result": {
+    "lora_id": "user/model",
+    "metadata": {
+      "loss": 0.1
+    }
+  },
+  "error": null
+}
+""".strip(),
+        encoding="utf-8",
+    )
+
+    (tmp_path / "20240101T000002-b.json").write_text(
+        (tmp_path / "20240101T000001-a.json").read_text(encoding="utf-8").replace("\"a\"", "\"b\"", 1).replace("prompt-a", "prompt-b"),
+        encoding="utf-8",
+    )
+
+    client = TestClient(web_app)
+    response = client.get("/v1/feedback/recent", params={"limit": 1})
+
+    assert response.status_code == 200
+    assert "CLaaS Recent Feedback" in response.text
+    assert "<table>" in response.text
+    assert "Expand" in response.text
+    assert "prompt-b" in response.text
+    assert "prompt-a" not in response.text
+
+
+def test_recent_feedback_dashboard_rejects_invalid_log(monkeypatch, tmp_path):
+    from claas import api
+
+    monkeypatch.setattr(api, "FEEDBACK_LOG_DIR", str(tmp_path))
+    (tmp_path / "20240101T000001-a.json").write_text("{}", encoding="utf-8")
+
+    client = TestClient(web_app)
+    response = client.get("/v1/feedback/recent")
+
+    assert response.status_code == 500
+
+
+def test_recent_feedback_dashboard_truncates_prompt_preview(monkeypatch, tmp_path):
+    from claas import api
+
+    monkeypatch.setattr(api, "FEEDBACK_LOG_DIR", str(tmp_path))
+    long_prompt = "x" * 400
+    (tmp_path / "20240101T000003-c.json").write_text(
+        f'''
+{{
+  "request_id": "c",
+  "timestamp_utc": "2024-01-01T00:00:03Z",
+  "status": "ok",
+  "phase": "done",
+  "lora_id": "user/model",
+  "teacher_mode": "self",
+  "request": {{
+    "lora_id": "user/model",
+    "prompt": "{long_prompt}",
+    "response": "response-c",
+    "feedback": "feedback-c",
+    "rollout_logprobs": null,
+    "training": {{
+      "learning_rate": 0.0001,
+      "alpha": 0.5,
+      "is_clip": 5.0,
+      "max_grad_norm": 1.0,
+      "kl_reg_weight": 0.001,
+      "teacher_top_k": 100,
+      "teacher_mode": "self"
+    }},
+    "orchestration": {{
+      "sleep_before": true,
+      "wake_after": true,
+      "wake_on_failure": true,
+      "sleep_level": 1
+    }}
+  }},
+  "vllm": {{
+    "slept": true,
+    "woke": true
+  }},
+  "timing_ms": {{
+    "sleep": 1,
+    "distill": 2,
+    "save": 0,
+    "wake": 1,
+    "logprobs": 0,
+    "total": 4
+  }},
+  "distill_result": {{
+    "lora_id": "user/model",
+    "metadata": {{
+      "loss": 0.1
+    }}
+  }},
+  "error": null
+}}
+'''.strip(),
+        encoding="utf-8",
+    )
+
+    client = TestClient(web_app)
+    response = client.get("/v1/feedback/recent", params={"limit": 1})
+
+    assert response.status_code == 200
+    assert "…" in response.text
+    assert long_prompt in response.text


### PR DESCRIPTION
### Motivation
- Provide a separate static template for the recent-feedback UI so operators can inspect recent feedback in a compact table with per-row expansion.
- Support very long prompts by truncating the table preview while preserving full content in an expandable details panel.
- Keep log parsing strict and rigid: validate records with `FeedbackLogRecord` and fail on malformed logs (no compatibility shims).

### Description
- Added `claas/templates/feedback_recent/index.html` and wired it via a new `FEEDBACK_DASHBOARD_TEMPLATE` constant for template-based rendering.
- Implemented `_feedback_prompt_preview(prompt: str, limit: int = 140) -> str` to build a single-line truncated prompt preview and `_feedback_dashboard_rows(records: list[FeedbackLogRecord]) -> str` to render table rows with an expandable detail row containing full prompt/response/feedback, timing, training metrics, vLLM state, and error payloads.
- Added `_read_recent_feedback_logs(limit: int)` usage and kept strict model validation via `FeedbackLogRecord.model_validate` when loading logs from `FEEDBACK_LOG_DIR`.
- Reworked the `/v1/feedback/recent` endpoint to accept a validated `limit` query param and return an `HTMLResponse` populated by the template and generated rows.
- All new/changed functions include concise google-style docstrings and HTML escaping for safety.

### Testing
- Compiled modified sources with `python -m compileall claas/api.py tests/test_api.py` and the compilation succeeded.
- Exercised the endpoint using `fastapi.testclient.TestClient` (internal smoke checks) to confirm `/v1/feedback/recent` returns HTTP 200, includes the `<table>` and `Expand` controls, and preserves full long prompts in the expanded details (checks passed).
- Captured a Playwright screenshot of the running endpoint (expanded row) to validate the visual layout and expansion behavior, and the capture succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69921469a570832ebb3d48621a1c7aa9)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a recent feedback dashboard endpoint that displays recent feedback logs with expandable details.
  * Dashboard shows feedback timing metrics, vLLM state, and error information for each record.
  * Supports configurable result limits via query parameter (default 20, range 1-200).
  * Features collapsible detail sections and truncated prompt previews for easy navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->