### PR TITLE
Move multi-step training into TrainingConfig with per-step IS correction

### DIFF
--- a/.claude/skills/setup-local/SKILL.md
+++ b/.claude/skills/setup-local/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: setup-local
-description: Set up the full CLaaS stack (vLLM + API + OpenClaw/Telegram) directly on the host without Docker. Use when Docker is unavailable or you want a native setup.
+description: Set up the full CLaaS stack (vLLM + API + OpenClaw/Telegram) locally. Uses Docker if available, falls back to native setup otherwise.
 ---
 
 # Setup Local

--- a/.claude/skills/setup-local/SKILL.md
+++ b/.claude/skills/setup-local/SKILL.md
@@ -46,6 +46,10 @@ uv pip install "torch>=2.1.0+cu128" torchvision torchaudio \
   --index-url https://download.pytorch.org/whl/cu128 --reinstall
 uv pip install "numpy<2.3"  # numba compatibility
 
+# Flash Attention 2 — required for local training (default attn_implementation)
+# Must install AFTER torch with --no-build-isolation so it links against the CUDA torch
+uv pip install flash-attn --no-build-isolation
+
 # OpenClaw
 npm install -g openclaw@latest
 ```
@@ -109,14 +113,19 @@ EOF
 
 ```bash
 LORA_ROOT="${HOME}/.local/share/claas/loras"
+# Create the aliases file if it doesn't exist (the start script reads it)
+[ -f "$LORA_ROOT/.aliases.json" ] || echo '{}' > "$LORA_ROOT/.aliases.json"
+
 export PATH="$(pwd)/.venv/bin:$PATH"  # puts 'vllm' on PATH
 export MODEL=Qwen/Qwen3-8B HOST=0.0.0.0 PORT=8000 API_KEY=sk-local
 export SERVED_MODEL_NAMES=qwen3-8b MAX_MODEL_LEN=32768 GPU_MEMORY_UTILIZATION=0.70
 export ENABLE_SLEEP_MODE=1 VLLM_SERVER_DEV_MODE=1 VLLM_ALLOW_RUNTIME_LORA_UPDATING=1
 export ENABLE_AUTO_TOOL_CHOICE=1 TOOL_CALL_PARSER=qwen3_xml
 export LORA_ROOT="$LORA_ROOT" LORA_ALIAS_FILE="$LORA_ROOT/.aliases.json" INCLUDE_ALIAS_LORAS=1
+# Enable LoRA even with no initial adapters — needed for runtime LoRA loading
+export EXTRA_ARGS='--enable-lora --max-lora-rank 32'
 
-bash scripts/openclaw-local/start_vllm_qwen3_8b.sh >> /tmp/vllm.log 2>&1 &
+bash docker/scripts/start_vllm_qwen3_8b.sh >> /tmp/vllm.log 2>&1 &
 
 # First run downloads Qwen3-8B (~16 GB) — expect 5-20 min
 until curl -sf http://localhost:8000/health; do sleep 5; done && echo "vLLM ready"
@@ -124,13 +133,17 @@ until curl -sf http://localhost:8000/health; do sleep 5; done && echo "vLLM read
 
 ### 4. Start CLaaS API
 
+The API must be started via its Hydra entry point (not bare `uvicorn`) so that the
+runtime config is loaded and `configure_web_app()` is called. Override `lora_root`
+to point to the local LoRA directory (the default `/loras` is the Docker path).
+
 ```bash
-CLAAS_CONFIG_NAME=local \
-CLAAS_LORA_ROOT="${HOME}/.local/share/claas/loras" \
-VLLM_BASE_URL=http://localhost:8000 \
 VLLM_API_KEY=sk-local \
-FEEDBACK_LOG_DIR=/tmp/feedback-logs \
-  uv run uvicorn claas.api:web_app --host 0.0.0.0 --port 8080 >> /tmp/claas-api.log 2>&1 &
+  uv run python -m runpy claas.api \
+    lora_root="${HOME}/.local/share/claas/loras" \
+    feedback_log_dir=/tmp/feedback-logs \
+    'hydra.run.dir=.' \
+    >> /tmp/claas-api.log 2>&1 &
 
 curl -sf http://localhost:8080/v1/health
 ```
@@ -172,6 +185,7 @@ Report the status of all four components and the Telegram bot username.
 | `Numba needs NumPy 2.2 or less` | `uv pip install "numpy<2.3"` |
 | `Python.h: No such file or directory` | Recreate venv with uv-managed Python (step 1 note) |
 | `No API key found for provider "local"` | Create `auth-profiles.json` (step 2) |
+| `flash_attn seems to be not installed` | `uv pip install flash-attn --no-build-isolation` (requires CUDA torch first) |
 | vLLM OOM | Lower `GPU_MEMORY_UTILIZATION` to `0.60` |
 
 ## Logs

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,11 @@ htmlcov/
 feedback_logs/
 .local_loras/
 .run-logs/
+.hydra/
+node_modules/
+package.json
+package-lock.json
+EXPERIMENTS.md
 
 # Runtime data (feedback logs, eval results, Hydra logs)
 data/feedback/

--- a/claas/core/types.py
+++ b/claas/core/types.py
@@ -57,6 +57,21 @@ class TrainingConfig(BaseModel):
         le=100,
         description="Number of top logprobs to request from teacher",
     )
+    steps_per_batch: int = Field(
+        default=1,
+        ge=1,
+        le=32,
+        description=(
+            "Number of optimizer updates to run on the same sampled batch. "
+            "Importance reweighting is recomputed after each step."
+        ),
+    )
+    feedback_repetitions: int = Field(
+        default=1,
+        ge=1,
+        le=16,
+        description="Times to repeat each feedback string before teacher scoring.",
+    )
 
 
 class SDPOLossInput(BaseModel):
@@ -473,5 +488,4 @@ class TextCompletionResponse(BaseModel):
     model: str
     choices: list[TextCompletionChoice]
     usage: CompletionUsage
-
 

--- a/claas/core/types.py
+++ b/claas/core/types.py
@@ -32,7 +32,7 @@ class TrainingConfig:
     max_grad_norm: float = 1.0
     kl_reg_weight: float = 0.0
     teacher_top_k: int = 100
-    steps_per_batch: int = 1
+    steps_per_batch: int = 4
     feedback_repetitions: int = 1
 
 

--- a/claas/core/types.py
+++ b/claas/core/types.py
@@ -35,6 +35,11 @@ class TrainingConfig:
     steps_per_batch: int = 4
     feedback_repetitions: int = 1
 
+    def __post_init__(self) -> None:
+        if self.steps_per_batch < 1:
+            msg = f"steps_per_batch must be >= 1, got {self.steps_per_batch}"
+            raise ValueError(msg)
+
 
 class SDPOLossInput(BaseModel):
     """Typed input for SDPO loss computation."""

--- a/claas/eval/README.md
+++ b/claas/eval/README.md
@@ -26,8 +26,6 @@ metrics:                             # metrics to evaluate per step
 
 num_steps: 20
 batch_size: 4
-steps_per_batch: 1                   # gradient updates per batch
-feedback_repetitions: 1              # times to repeat feedback string
 collapse_steps: [0, 5, 10, 15, 19]  # steps where collapse metric runs
 plots: true                          # generate matplotlib plots
 seed: 42
@@ -35,6 +33,10 @@ lora_id_prefix: eval
 output_dir: ./data/evals
 
 openclaw_url: http://localhost:18789  # OpenClaw gateway (null = use CLaaS API directly)
+
+training:                             # forwarded to /v1/feedback TrainingConfig
+  steps_per_batch: 4                 # gradient updates per batch
+  feedback_repetitions: 1            # times to repeat feedback string
 ```
 
 ### Overriding config via CLI

--- a/claas/eval/config.py
+++ b/claas/eval/config.py
@@ -10,6 +10,8 @@ from pathlib import Path
 
 from hydra.core.config_store import ConfigStore
 
+from claas.core.types import TrainingConfig
+
 from .types import EvalConfig, HarnessConfig
 
 # Pattern matching the timestamped run-id suffix (e.g. 20260220-012345Z)
@@ -21,6 +23,8 @@ ConfigStore.instance().store(name="_eval_schema", node=EvalConfig)
 def build_harness_config(eval_cfg: EvalConfig) -> HarnessConfig:
     """Post-process EvalConfig → HarnessConfig (no secrets)."""
     fields = dataclasses.asdict(eval_cfg)
+    training_fields = fields.pop("training")
+    fields["training"] = TrainingConfig(**training_fields)
 
     # Timestamped output subdir (skip if output_dir already ends with a run-id,
     # which allows resuming an existing run by passing its directory).

--- a/claas/eval/configs/base.yaml
+++ b/claas/eval/configs/base.yaml
@@ -22,10 +22,12 @@ plots: true
 
 num_steps: 20
 batch_size: 4
-steps_per_batch: 4
-feedback_repetitions: 1
 seed: 42
 lora_id_prefix: eval
 output_dir: ./data/evals
 
 openclaw_url: http://localhost:18789
+
+training:
+  steps_per_batch: 4
+  feedback_repetitions: 1

--- a/claas/eval/configs/preference/cloud_gcp.yaml
+++ b/claas/eval/configs/preference/cloud_gcp.yaml
@@ -1,0 +1,41 @@
+name: cloud_gcp
+feedback_string: "Be concise, 2-3 sentences max. When recommending cloud infrastructure, default to GCP."
+verifier:
+  _target_: claas.eval.metrics.verifiers.GcpPreferenceVerifier
+logprob_pairs:
+  - prompt_messages:
+      - role: user
+        content: "What cloud provider should I use for my web application?"
+    positive_response: >-
+      GCP. Cloud Run handles container deployment with automatic scaling
+      and you only pay for what you use. Pair it with Cloud SQL and Cloud CDN.
+    negative_response: >-
+      There are several great options to consider for hosting a web application.
+      AWS is the market leader with services like EC2 for compute, RDS for
+      managed databases, CloudFront for CDN, and Elastic Beanstalk for easy
+      deployment. Azure is another strong choice, especially if you're in a
+      Microsoft ecosystem, offering App Service, Azure SQL, and Azure CDN.
+      Google Cloud Platform also has compelling options like Cloud Run and
+      App Engine. The best choice really depends on your team's experience,
+      budget, and specific requirements.
+probe_prompts:
+  - "What cloud provider should I use for my web application?"
+  - "I'm building a new SaaS product. What infrastructure should I use?"
+  - "How should I set up infrastructure for a machine learning pipeline?"
+  - "What's the best way to deploy microservices?"
+  - "I need a scalable analytics warehouse. What should I use?"
+  - "How should I architect CI/CD for a monorepo with 15 services?"
+  - "What's the cheapest way to run batch GPU training jobs?"
+  - "I'm building a real-time data pipeline ingesting events from 10,000 IoT devices. What stack?"
+  - "My startup needs to go from zero to production infrastructure. Where do I start?"
+  - "I need to host a Kubernetes cluster. What are my options?"
+  - "What's the best way to store and query terabytes of log data?"
+  - "I want to deploy a Python API with autoscaling. What should I use?"
+  - "How do I set up a data lake for my analytics team?"
+  - "What infrastructure do I need for a multiplayer game backend?"
+  - "I'm migrating from on-prem to cloud. Where should I start?"
+  - "What's the most cost-effective way to run cron jobs in the cloud?"
+  - "I need to serve a fine-tuned LLM in production. What are my options?"
+  - "How should I handle file storage and CDN for a media-heavy app?"
+  - "What's the best setup for running distributed Spark jobs?"
+  - "I need a managed Postgres database with high availability. Recommendations?"

--- a/claas/eval/metrics/verifiers.py
+++ b/claas/eval/metrics/verifiers.py
@@ -100,6 +100,44 @@ class IdentityVerifier:
         return VerifierResult(score=1.0 if passed else 0.0, passed=passed)
 
 
+# Regex for GCP-related terms (case-insensitive)
+_GCP_TERMS_RE = re.compile(
+    r"\b(?:"
+    r"google\s+cloud|gcp|cloud\s+run|cloud\s+functions|gke|"
+    r"bigquery|cloud\s+sql|cloud\s+storage|compute\s+engine|"
+    r"app\s+engine|cloud\s+pub/?sub|firestore|cloud\s+build|"
+    r"vertex\s+ai|cloud\s+cdn|cloud\s+armor|anthos"
+    r")\b",
+    re.IGNORECASE,
+)
+
+# Regex for competing cloud provider names
+_COMPETITOR_RE = re.compile(
+    r"\b(?:aws|amazon\s+web\s+services|azure|microsoft\s+azure)\b",
+    re.IGNORECASE,
+)
+
+
+class GcpPreferenceVerifier:
+    """Pass when the response recommends GCP and doesn't primarily push competitors."""
+
+    def __call__(self, response: str) -> VerifierResult:
+        gcp_mentions = len(_GCP_TERMS_RE.findall(response))
+        competitor_mentions = len(_COMPETITOR_RE.findall(response))
+
+        if gcp_mentions == 0:
+            return VerifierResult(score=0.0, passed=False)
+
+        # GCP must be mentioned more than competitors combined
+        if competitor_mentions >= gcp_mentions:
+            score = gcp_mentions / (gcp_mentions + competitor_mentions)
+            return VerifierResult(score=score, passed=False)
+
+        # Graduated score: 1 mention = 0.5, 2+ = 1.0
+        score = min(1.0, 0.5 * gcp_mentions)
+        return VerifierResult(score=score, passed=gcp_mentions >= 2)
+
+
 def run_verifier(verifier: Verifier, response: str) -> VerifierResult:
     """Run a verifier on a response (thinking blocks stripped)."""
     return verifier(strip_thinking(response))

--- a/claas/eval/runner.py
+++ b/claas/eval/runner.py
@@ -81,7 +81,7 @@ async def _submit_feedback(
             adv_abs_mean_raw=metadata["adv_abs_mean_raw"],
             completion_len=metadata["completion_len"],
             batch_size=metadata["batch_size"],
-            steps_per_batch_applied=metadata["steps_per_batch_applied"],
+            steps_per_batch_applied=metadata.get("steps_per_batch_applied", 1),
         )
 
     return LocalDistillMetrics(
@@ -89,7 +89,7 @@ async def _submit_feedback(
         kl_reg=metadata.get("kl_reg"),
         mean_is_ratio=metadata.get("mean_is_ratio"),
         clip_fraction=metadata.get("clip_fraction"),
-        steps_per_batch_applied=metadata["steps_per_batch_applied"],
+        steps_per_batch_applied=metadata.get("steps_per_batch_applied", 1),
     )
 
 

--- a/claas/inference/vllm.py
+++ b/claas/inference/vllm.py
@@ -167,6 +167,16 @@ class VllmBackend(InferenceBackend):
 
         usage = data.get("usage", {})
 
+        # vLLM includes the stop token (e.g. <|im_end|>) in logprobs but the
+        # tokenizer doesn't produce it when re-encoding the text.  Trim the
+        # logprobs so the two sequences stay aligned.
+        if (
+            response_logprobs is not None
+            and response_token_ids
+            and len(response_logprobs) > len(response_token_ids)
+        ):
+            response_logprobs = response_logprobs[: len(response_token_ids)]
+
         return CompletionResult(
             content=content,
             raw_prompt=raw_prompt,

--- a/claas/training/engine/tinker/engine.py
+++ b/claas/training/engine/tinker/engine.py
@@ -233,8 +233,9 @@ class TinkerTrainingEngine(TrainingEngine):
             await training_client.optim_step_async(
                 T.AdamParams(learning_rate=lr, beta1=0.9, beta2=0.95)
             )
-            if hasattr(fwd_bwd, "metrics") and fwd_bwd.metrics:
-                final_fwd_metrics = dict(fwd_bwd.metrics)
+            fwd_metrics = getattr(fwd_bwd, "metrics", None)
+            if fwd_metrics:
+                final_fwd_metrics = dict(fwd_metrics)
 
             n = len(sample_metrics)
             total_completion_len = sum(m["completion_len"] for m in sample_metrics)

--- a/tests/test_eval_config.py
+++ b/tests/test_eval_config.py
@@ -77,9 +77,14 @@ def test_collapse_steps_list() -> None:
     assert config.collapse_steps == [0, 5, 10]
 
 
-def test_steps_per_batch_from_config() -> None:
-    config = build_harness_config(_compose_eval_config(["steps_per_batch=3"]))
-    assert config.steps_per_batch == 3
+def test_training_steps_per_batch_from_config() -> None:
+    config = build_harness_config(_compose_eval_config(["training.steps_per_batch=3"]))
+    assert config.training.steps_per_batch == 3
+
+
+def test_eval_top_level_steps_per_batch_rejected() -> None:
+    with pytest.raises(Exception):
+        _compose_eval_config(["steps_per_batch=3"])
 
 
 def test_hydra_config_custom_dir() -> None:

--- a/tests/test_eval_runner.py
+++ b/tests/test_eval_runner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from claas.core.types import TrainingConfig
 from claas.eval.types import (
     HarnessConfig,
     LocalDistillMetrics,
@@ -33,6 +34,7 @@ def test_tinker_distill_metrics_fields():
     assert m.adv_abs_mean_raw == 0.60
     assert m.completion_len == 128
     assert m.batch_size == 4
+    assert m.steps_per_batch_applied == 1
 
 
 def test_tinker_distill_metrics_defaults():
@@ -47,6 +49,7 @@ def test_tinker_distill_metrics_defaults():
     )
     assert m.completion_len == 0
     assert m.batch_size == 0
+    assert m.steps_per_batch_applied == 1
 
 
 # ── step_result_from_dict deserialization ─────────────────────────────
@@ -75,11 +78,13 @@ def test_step_result_from_dict_tinker_metrics():
             "adv_abs_mean_raw": 0.55,
             "completion_len": 64,
             "batch_size": 4,
+            "steps_per_batch_applied": 3,
         },
     }
     result = step_result_from_dict(data)
     assert isinstance(result.sdpo_metrics, TinkerDistillMetrics)
     assert result.sdpo_metrics.adv_mean == -0.5
+    assert result.sdpo_metrics.steps_per_batch_applied == 3
 
 
 def test_step_result_from_dict_local_metrics():
@@ -91,11 +96,13 @@ def test_step_result_from_dict_local_metrics():
             "kl_reg": 0.02,
             "mean_is_ratio": 1.01,
             "clip_fraction": 0.05,
+            "steps_per_batch_applied": 2,
         },
     }
     result = step_result_from_dict(data)
     assert isinstance(result.sdpo_metrics, LocalDistillMetrics)
     assert result.sdpo_metrics.distill_loss == 0.35
+    assert result.sdpo_metrics.steps_per_batch_applied == 2
 
 
 def test_step_result_from_dict_no_metrics():
@@ -107,28 +114,19 @@ def test_step_result_from_dict_no_metrics():
 # ── HarnessConfig defaults ───────────────────────────────────────────
 
 
-def test_steps_per_batch_default():
-    """HarnessConfig.steps_per_batch defaults to 4."""
+def test_training_config_default():
+    """HarnessConfig.training defaults to TrainingConfig defaults."""
     config = HarnessConfig()
-    assert config.steps_per_batch == 4
+    assert config.training == TrainingConfig()
 
 
-def test_steps_per_batch_custom():
-    """HarnessConfig.steps_per_batch can be set."""
-    config = HarnessConfig(steps_per_batch=3)
-    assert config.steps_per_batch == 3
-
-
-def test_feedback_repetitions_default():
-    """HarnessConfig.feedback_repetitions defaults to 1."""
-    config = HarnessConfig()
-    assert config.feedback_repetitions == 1
-
-
-def test_feedback_repetitions_custom():
-    """HarnessConfig.feedback_repetitions can be set."""
-    config = HarnessConfig(feedback_repetitions=4)
-    assert config.feedback_repetitions == 4
+def test_training_config_custom():
+    """HarnessConfig.training accepts custom steps/repetitions."""
+    config = HarnessConfig(
+        training=TrainingConfig(steps_per_batch=3, feedback_repetitions=4),
+    )
+    assert config.training.steps_per_batch == 3
+    assert config.training.feedback_repetitions == 4
 
 
 # ── StepResult sub_step_count ────────────────────────────────────────

--- a/tests/test_tinker_engine.py
+++ b/tests/test_tinker_engine.py
@@ -408,7 +408,7 @@ def test_engine_distill_full_flow(tinker_engine, mock_training_client):
 
     payload = DistillBatchRequestPayload(
         lora_id="test/lora",
-        training=TrainingConfig(),
+        training=TrainingConfig(steps_per_batch=1),
         samples=[
             DistillBatchItem(
                 prompt="Hello",
@@ -487,7 +487,7 @@ def test_engine_distill_uses_provided_response_logprobs(tinker_engine, mock_trai
     # Provide response_logprobs matching the response length (5 tokens)
     payload = DistillBatchRequestPayload(
         lora_id="test/lora",
-        training=TrainingConfig(),
+        training=TrainingConfig(steps_per_batch=1),
         samples=[
             DistillBatchItem(
                 prompt="Hello",
@@ -633,7 +633,7 @@ def test_engine_distill_batch_multiple_samples(tinker_engine, mock_training_clie
 
     payload = DistillBatchRequestPayload(
         lora_id="test/lora",
-        training=TrainingConfig(),
+        training=TrainingConfig(steps_per_batch=1),
         samples=samples,
     )
 
@@ -777,7 +777,7 @@ def test_engine_distill_uses_response_token_ids(tinker_engine, mock_training_cli
 
     payload = DistillBatchRequestPayload(
         lora_id="test/lora",
-        training=TrainingConfig(),
+        training=TrainingConfig(steps_per_batch=1),
         samples=[
             DistillBatchItem(
                 prompt="(ignored prompt text)",


### PR DESCRIPTION
## Summary
- move multi-step training controls (`steps_per_batch`, `feedback_repetitions`) from eval-owned settings into `TrainingConfig`
- remove eval-side sub-step loop and pass typed `training` config through `FeedbackItem` in each `/v1/feedback` request
- execute multi-step updates inside training engines (local/modal + tinker)
- recompute behavior-policy logprobs after each optimizer step for off-policy importance reweighting
- include engine metadata (`steps_per_batch_applied`, per-step metrics) and wire eval `sub_step_count` to that metadata
- update eval Hydra schema/config/docs and related tests

## Key Implementation Notes
- added strict `TrainingConfig` fields:
  - `steps_per_batch`
  - `feedback_repetitions`
- introduced Hydra-safe `EvalTrainingConfig` and convert to runtime `TrainingConfig` in `build_harness_config`
- tinker engine now refreshes student logprobs between steps using `save_weights_and_get_sampling_client_async`

## Validation
- `uv run ruff check claas/ tests/ --fix`
- `uv run pytest tests/ -q -m "not integration"`
  - result: `109 passed, 26 skipped, 5 deselected`
- `uv run ty check`
  - unresolved-import diagnostics for heavy runtime deps (`torch`, `tinker`, `transformers`) are expected in this environment


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for multi-step training per batch with configurable `steps_per_batch` parameter
  * Added `feedback_repetitions` configuration option for enhanced training control
  * New metric `steps_per_batch_applied` tracks actual steps executed per batch

* **Documentation**
  * Updated configuration structure to use nested training block for training-specific parameters

* **Refactor**
  * Reorganized configuration hierarchy to consolidate training settings under dedicated training section
<!-- end of auto-generated comment: release notes by coderabbit.ai -->