### PR TITLE
fix: add feedbackBatchSize to plugin config schema

### DIFF
--- a/plugins/claas-feedback/openclaw.plugin.json
+++ b/plugins/claas-feedback/openclaw.plugin.json
@@ -12,6 +12,10 @@
       "loraId": {
         "type": "string",
         "description": "LoRA adapter ID to update (e.g. openclaw/assistant-latest)"
+      },
+      "feedbackBatchSize": {
+        "type": "number",
+        "description": "Number of feedback samples to batch before triggering distillation"
       }
     }
   }

--- a/plugins/claas-feedback/openclaw.plugin.json
+++ b/plugins/claas-feedback/openclaw.plugin.json
@@ -14,8 +14,9 @@
         "description": "LoRA adapter ID to update (e.g. openclaw/assistant-latest)"
       },
       "feedbackBatchSize": {
-        "type": "number",
-        "description": "Number of feedback samples to batch before triggering distillation"
+       "type": "integer",
+       "minimum": 1,
+       "description": "Number of feedback samples to batch before triggering distillation"
       }
     }
   }


### PR DESCRIPTION
## Problem
The `feedbackBatchSize` config key was being silently stripped 
by OpenClaw before reaching the claas-feedback plugin.

This happened because `openclaw.plugin.json` uses a strict 
schema that discards any keys not explicitly declared in 
`properties`. Since `feedbackBatchSize` was missing from the 
schema, setting `feedbackBatchSize: 1` in the config had no 
effect — the plugin always used its default batch size.

## Fix
Added `feedbackBatchSize` as a declared property in the 
configSchema, with type `integer` and `minimum: 1` to 
ensure only positive whole numbers are accepted.

## Related
Closes #20