### PR TITLE
fix: add Tinker warmup step before integration tests

### DIFF
--- a/tests/integration/run_tinker_stack_integration.sh
+++ b/tests/integration/run_tinker_stack_integration.sh
@@ -47,6 +47,16 @@ compose up -d --build
 echo "==> Waiting for CLaaS API ..."
 timeout 120 bash -c 'until curl -sf http://127.0.0.1:8080/ >/dev/null 2>&1; do sleep 5; done'
 
+# ── 2b. Warm up Tinker (tokenizer downloads on first inference) ────
+echo "==> Warming up Tinker inference (tokenizer download may take >120s) ..."
+timeout 300 bash -c '
+  until curl -sf \
+    -H "Content-Type: application/json" \
+    -X POST http://127.0.0.1:8080/v1/chat/completions \
+    -d "{\"model\":\"'"$MODEL"'\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"max_tokens\":1}" \
+    -o /dev/null 2>&1; do sleep 10; done'
+echo "==> Tinker warmed up."
+
 echo "==> Waiting for OpenClaw gateway ..."
 timeout 180 bash -c '
   until curl -sf \


### PR DESCRIPTION
## Problem
The Tinker proxy cold-starts on first inference because the 
tokenizer downloads on demand (>120s). The existing health 
check only confirms the API server is up, not that it is 
ready to serve inference requests.

This caused the E2E integration tests to fail immediately 
after startup — the first real inference request would time 
out while the tokenizer was still downloading.

## Fix
Added a warmup step (step 2b) that sends a real inference 
request to the CLaaS API and retries until it succeeds 
(timeout 300s) before the OpenClaw gateway check and 
test run begin.

## Related
Closes #20